### PR TITLE
doc: include "hourly" directory in filename template per the Intake yaml file

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ The download data is provided as record for every unique combination of:
 
 The storage format is Parquet, one file per day, with SNAPPY compression.  Files are hosted on S3, with the naming convention:
 
-  - `s3://anaconda-package-data/conda/[year]/[month]/[year]-[month]-[day].parquet`
+  - `s3://anaconda-package-data/conda/hourly/[year]/[month]/[year]-[month]-[day].parquet`
 
 
 ## Data Catalog


### PR DESCRIPTION
I could not download data according to the template in the README until I added the `hourly/` piece to the path.

Without hourly:

```
$ aws2 s3 cp s3://anaconda-package-data/conda/2019/10/2019-10-31.parquet .
fatal error: An error occurred (404) when calling the HeadObject operation: \
Key "conda/2019/10/2019-10-31.parquet" does not exist
```

With hourly:

```
$ aws2 s3 cp s3://anaconda-package-data/conda/hourly/2019/10/2019-10-31.parquet .
download: s3://anaconda-package-data/conda/hourly/2019/10/2019-10-31.parquet \
to ./2019-10-31.parquet
```

See [Intake YAML file](https://raw.githubusercontent.com/ContinuumIO/anaconda-package-data/master/catalog/anaconda_package_data.yaml):

```
urlpath: 's3://anaconda-package-data/conda/hourly/{{ "%04d" | format(year) }}/{{ "%02d" | format(month) }}/'
  '{{ "%04d" | format(year) }}-{{ "%02d" | format(month) }}-{{ "%02d" | format(day) }}.parquet'
```